### PR TITLE
CI: Run linters and tests also on scheduled events

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -98,7 +98,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        if: ${{ github.event_name == 'pull_request'|| github.event_name == 'push' }}
+        if: ${{ github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'schedule' }}
         uses: actions/checkout@v4
 
       - name: Check out the repository (workflow_dispatch)


### PR DESCRIPTION
## Problem
Nightly scheduled jobs are failing with the current CI configuration, because `actions/checkout` has been skipped.
- https://github.com/crate/dbt-cratedb2/actions/runs/12450732964