### PR TITLE
SQL: Add support for `{CREATE,DROP} SCHEMA`, provided by CrateDB 6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 - QA: Validated against dbt-core 1.10
+- SQL: Added support for `{CREATE,DROP} SCHEMA`, provided by CrateDB 6.2
 
 ## v0.1.1 - March 24, 2025
 - Fixed changes not being materialized when using an incremental materialization

--- a/dbt/include/cratedb/macros/adapters.sql
+++ b/dbt/include/cratedb/macros/adapters.sql
@@ -52,27 +52,6 @@
   {%- endcall %}
 {% endmacro %}
 
-{% macro cratedb__create_schema(relation) -%}
-  {% if relation.database -%}
-    {{ adapter.verify_database(relation.database) }}
-  {%- endif -%}
-  {%- call statement('create_schema') -%}
-  {# create schema if not exists {{ relation.without_identifier().include(database=False) }} #}
-    SELECT 1
-  {%- endcall -%}
-{% endmacro %}
-
-{% macro cratedb__drop_schema(relation) -%}
-  {% if relation.database -%}
-    {{ adapter.verify_database(relation.database) }}
-  {%- endif -%}
-  {%- call statement('drop_schema') -%}
-  {# drop schema if exists {{ relation.without_identifier().include(database=False) }} cascade #}
-    SELECT 1
-  {%- endcall -%}
-{% endmacro %}
-
-
 {# CrateDB: `COMMENT ON` not supported. #}
 {% macro cratedb__alter_relation_comment(relation, comment) %}
   {% set escaped_comment = postgres_escape_comment(comment) %}

--- a/tests/functional/adapter/test_basic.py
+++ b/tests/functional/adapter/test_basic.py
@@ -21,50 +21,8 @@ from dbt.tests.adapter.basic.test_table_materialization import BaseTableMaterial
 from dbt.tests.adapter.basic.test_validate_connection import BaseValidateConnection
 
 
-models__model_sql = """
-
-{% set upstream = ref('upstream') %}
-
-{% if execute %}
-    {# don't ever do any of this #}
-
-    {# FIXME: CrateDB: `DROP SCHEMA` not supported #}
-    {%- do adapter.drop_schema(upstream) -%}
-
-    {# FIXME: CrateDB workaround #}
-    {% set table_fqn = adapter.get_relation(upstream.database, upstream.schema, upstream.identifier) %}
-    {%- do drop_relation_if_exists(table_fqn) -%}
-
-    {% set existing = adapter.get_relation(upstream.database, upstream.schema, upstream.identifier) %}
-    {% if existing is not none %}
-        {% do exceptions.raise_compiler_error('expected ' ~ ' to not exist, but it did') %}
-    {% endif %}
-
-    {%- do adapter.create_schema(upstream) -%}
-
-    {% set sql = create_view_as(upstream, 'select 2 as id') %}
-    {% do run_query(sql) %}
-{% endif %}
-
-
-select * from {{ upstream }}
-
-"""
-
-
 class TestBaseCaching(BaseAdapterMethod):
-    @pytest.fixture(scope="class")
-    def models(self):
-        from dbt.tests.adapter.basic.test_adapter_methods import (
-            models__upstream_sql,
-            models__expected_sql,
-        )
-
-        return {
-            "upstream.sql": models__upstream_sql,
-            "expected.sql": models__expected_sql,
-            "model.sql": models__model_sql,
-        }
+    pass
 
 
 class TestSimpleMaterializations(BaseSimpleMaterializations):

--- a/tests/functional/adapter/test_cratedb.py
+++ b/tests/functional/adapter/test_cratedb.py
@@ -95,10 +95,6 @@ class TestCrateDB:
 
     @pytest.fixture(autouse=True)
     def clean_up(self, project):
-        """
-        TODO: The standard way of cleaning up resources probably does not work,
-              because `drop_schema` is not implemented, and has been made a no-op.
-        """
         yield
         with project.adapter.connection_named("__test"):
             relation = project.adapter.Relation.create(

--- a/tests/functional/adapter/test_relations.py
+++ b/tests/functional/adapter/test_relations.py
@@ -1,4 +1,3 @@
-import pytest
 from dbt.tests.adapter.relations.test_changing_relation_type import BaseChangeRelationTypeValidator
 from dbt.tests.adapter.relations.test_dropping_schema_named import BaseDropSchemaNamed
 
@@ -7,6 +6,5 @@ class TestChangeRelationTypes(BaseChangeRelationTypeValidator):
     pass
 
 
-@pytest.mark.skip("CrateDB: `DROP SCHEMA` not supported")
 class TestDropSchemaNamed(BaseDropSchemaNamed):
     pass

--- a/tests/functional/adapter/test_simple_copy.py
+++ b/tests/functional/adapter/test_simple_copy.py
@@ -6,7 +6,6 @@ from dbt.tests.adapter.simple_copy.test_simple_copy import (
 )
 
 
-@pytest.mark.skip("CrateDB: `CREATE SCHEMA` not supported")
 class TestSimpleCopyUppercase(BaseSimpleCopyUppercase):
     @pytest.fixture(scope="class")
     def dbt_profile_target(self):

--- a/tests/functional/sources/test_simple_source.py
+++ b/tests/functional/sources/test_simple_source.py
@@ -35,13 +35,9 @@ class SuccessfulSourcesTest(BaseSourcesTest):
         return {"macro.sql": macros_macro_sql}
 
     def _create_schemas(self, project):
-        """
-        # TODO: CrateDB adjustments.
-
         schema = self.alternative_schema(project.test_schema)
         project.run_sql(f"drop schema if exists {schema} cascade")
         project.run_sql(f"create schema {schema}")
-        """
 
     def alternative_schema(self, test_schema):
         return test_schema + "_other"

--- a/tests/functional/test_external_reference.py
+++ b/tests/functional/test_external_reference.py
@@ -24,8 +24,7 @@ class TestExternalReference:
 
     def test_external_reference(self, project, unique_schema):
         external_schema = unique_schema + "z"
-        # TODO: CrateDB `CREATE SCHEMA` not supported.
-        # project.run_sql(f'create schema "{external_schema}"')
+        project.run_sql(f'create schema "{external_schema}"')
         project.run_sql(f'create table "{external_schema}"."external" (id integer)')
         project.run_sql(f'insert into "{external_schema}"."external" values (1), (2)')
 
@@ -49,8 +48,7 @@ class TestExternalDependency:
         assert len(results) == 1
 
         external_schema = unique_schema + "z"
-        # TODO: CrateDB `CREATE SCHEMA` not supported.
-        # project.run_sql(f'create schema "{external_schema}"')
+        project.run_sql(f'create schema "{external_schema}"')
         project.run_sql(
             f'create view "{external_schema}"."external" as (select * from {unique_schema}.model)'
         )

--- a/tests/unit/test_connection.py
+++ b/tests/unit/test_connection.py
@@ -103,7 +103,7 @@ class TestPostgresConnection(TestCase):
         )
         self.adapter.drop_schema(relation)
 
-        self.mock_execute.assert_has_calls([mock.call("/* dbt */\n\n    SELECT 1", None)])
+        self.mock_execute.assert_has_calls([mock.call('/* dbt */\ndrop schema if exists "test_schema" cascade', None)])
 
     def test_quoting_on_drop(self):
         relation = self.adapter.Relation.create(


### PR DESCRIPTION
## About
CrateDB 6.2 will support `CREATE SCHEMA` and `DROP SCHEMA`.

## References
- https://github.com/crate/crate/issues/14601

## Backlog
dbt needs `DROP SCHEMA ... CASCADE`, as observed per GH-33.
```
DependentObjectsStillExist: Cannot drop schema "test17648547769351166905_test_basic" because other objects depend on it
```
- https://github.com/crate/dbt-cratedb2/actions/runs/19930517047/job/57141121841?pr=33#step:9:932