### PR TITLE
SQL: Remove `CASCADE` from `DROP SCHEMA`

### DIFF
--- a/dbt/include/cratedb/macros/adapters.sql
+++ b/dbt/include/cratedb/macros/adapters.sql
@@ -52,6 +52,15 @@
   {%- endcall %}
 {% endmacro %}
 
+{% macro cratedb__drop_schema(relation) -%}
+  {% if relation.database -%}
+    {{ adapter.verify_database(relation.database) }}
+  {%- endif -%}
+  {%- call statement('drop_schema') -%}
+    drop schema if exists {{ relation.without_identifier().include(database=False) }}
+  {%- endcall -%}
+{% endmacro %}
+
 {# CrateDB: `COMMENT ON` not supported. #}
 {% macro cratedb__alter_relation_comment(relation, comment) %}
   {% set escaped_comment = postgres_escape_comment(comment) %}

--- a/tests/functional/graph_selection/test_graph_selection.py
+++ b/tests/functional/graph_selection/test_graph_selection.py
@@ -34,7 +34,7 @@ def assert_correct_schemas(project):
 
 
 def clear_schema(project):
-    project.run_sql("drop schema if exists {schema} cascade")
+    project.run_sql("drop schema if exists {schema}")
     project.run_sql("create schema {schema}")
 
 

--- a/tests/functional/sources/test_simple_source.py
+++ b/tests/functional/sources/test_simple_source.py
@@ -36,7 +36,7 @@ class SuccessfulSourcesTest(BaseSourcesTest):
 
     def _create_schemas(self, project):
         schema = self.alternative_schema(project.test_schema)
-        project.run_sql(f"drop schema if exists {schema} cascade")
+        project.run_sql(f"drop schema if exists {schema}")
         project.run_sql(f"create schema {schema}")
 
     def alternative_schema(self, test_schema):

--- a/tests/unit/test_connection.py
+++ b/tests/unit/test_connection.py
@@ -103,7 +103,7 @@ class TestPostgresConnection(TestCase):
         )
         self.adapter.drop_schema(relation)
 
-        self.mock_execute.assert_has_calls([mock.call('/* dbt */\ndrop schema if exists "test_schema" cascade', None)])
+        self.mock_execute.assert_has_calls([mock.call('/* dbt */\ndrop schema if exists "test_schema"', None)])
 
     def test_quoting_on_drop(self):
         relation = self.adapter.Relation.create(


### PR DESCRIPTION
### About

Let's try without `DROP SCHEMA ... CASCADE`. CrateDB nightly doesn't support it yet.

### References

- GH-32
- https://github.com/crate/crate/issues/18794